### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled format string

### DIFF
--- a/Modules/Promasy.Modules.Files/FilesModule.cs
+++ b/Modules/Promasy.Modules.Files/FilesModule.cs
@@ -36,7 +36,7 @@ public class FilesModule : IModule
                 var bytes = await fs.ReadFileAsync(request.FileName);
                 if (!bytes.Any())
                 {
-                    throw new ApiException(string.Format(localizer["File {0} not found"], request.FileName),
+                    throw new ApiException(localizer["File {0} not found", request.FileName],
                         StatusCodes.Status404NotFound);
                 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/AndriiLab/Promasy.Net/security/code-scanning/1](https://github.com/AndriiLab/Promasy.Net/security/code-scanning/1)

To fix the problem, we should ensure that the format string used in `string.Format` is a constant string and not influenced by any untrusted source. In this case, we can directly use the `localizer` to format the string without using `string.Format`.

- Replace the `string.Format` call with the `localizer`'s built-in formatting capabilities.
- Ensure that the format string is a constant and not influenced by external input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
