### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/Modules/Promasy.Modules.Files/Services/FileStorage.cs
+++ b/Modules/Promasy.Modules.Files/Services/FileStorage.cs
@@ -1,4 +1,5 @@
 ﻿using Promasy.Application.Interfaces;
+using Promasy.Core.Exceptions;
 
 namespace Promasy.Modules.Files.Services;
 
@@ -8,26 +9,17 @@ internal class FileStorage : IFileStorage
 
     public Task<byte[]> ReadFileAsync(string fileName)
     {
-        if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
-        {
-            throw new ArgumentException("Invalid file name");
-        }
+        Ensure.FileNameSafety(fileName);
 
         var path = Path.Combine(Directory.GetCurrentDirectory(), ReportsPath, fileName);
-        if (!File.Exists(path))
-        {
-            return Task.FromResult(Array.Empty<byte>());
-        }
-
-        return File.ReadAllBytesAsync(path);
+        return File.Exists(path)
+            ? File.ReadAllBytesAsync(path)
+            : Task.FromResult(Array.Empty<byte>());
     }
 
     public string GetPathForFile(string fileName)
     {
-        if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
-        {
-            throw new ArgumentException("Invalid file name");
-        }
+        Ensure.FileNameSafety(fileName);
 
         if (!Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), ReportsPath)))
         {

--- a/Modules/Promasy.Modules.Files/Services/FileStorage.cs
+++ b/Modules/Promasy.Modules.Files/Services/FileStorage.cs
@@ -8,6 +8,11 @@ internal class FileStorage : IFileStorage
 
     public Task<byte[]> ReadFileAsync(string fileName)
     {
+        if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
+        {
+            throw new ArgumentException("Invalid file name");
+        }
+
         var path = Path.Combine(Directory.GetCurrentDirectory(), ReportsPath, fileName);
         if (!File.Exists(path))
         {
@@ -19,6 +24,11 @@ internal class FileStorage : IFileStorage
 
     public string GetPathForFile(string fileName)
     {
+        if (fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
+        {
+            throw new ArgumentException("Invalid file name");
+        }
+
         if (!Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), ReportsPath)))
         {
             Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), ReportsPath));

--- a/Promasy.Core/Exceptions/Ensure.cs
+++ b/Promasy.Core/Exceptions/Ensure.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Promasy.Core.Exceptions;
+
+public static class Ensure
+{
+    public static void FileNameSafety(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        
+        if (fileName.Contains("..") || fileName.Contains('/') || fileName.Contains('\\'))
+        {
+            throw new ArgumentException("Invalid file name");
+        }
+    }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/AndriiLab/Promasy.Net/security/code-scanning/3](https://github.com/AndriiLab/Promasy.Net/security/code-scanning/3)

To fix the problem, we need to validate the `fileName` parameter to ensure it does not contain any path traversal characters or sequences. This can be done by checking for the presence of "..", "/", or "\\" in the `fileName`. If any of these characters or sequences are found, the input should be rejected.

The best way to fix the problem without changing existing functionality is to add a validation step in the `ReadFileAsync` and `GetPathForFile` methods to ensure the `fileName` is safe to use. If the validation fails, the methods should return an appropriate response or throw an exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
